### PR TITLE
fixes false export error message by byte.decode()

### DIFF
--- a/Shp2PgsqlGUI.py
+++ b/Shp2PgsqlGUI.py
@@ -422,7 +422,7 @@ class exportThread(QtCore.QThread):
 
         try:
             output = check_output(args)
-            self.write_log.emit(output)
+            self.write_log.emit(output.decode("utf-8", "ignore"))
         except Exception as e:
             self.write_log.emit(str(e))
             self.write_log.emit("An error occured during {}.{} export.".format(self.schema, self.table))


### PR DESCRIPTION
I had this misleading error message during export with python3.8 on an arm64 system. Probably it is occurring on other architectures as well. Although there was an error message, the output was fine.

Error message on the log window:

exportThread.write_log[str].emit(): argument 1 has unexpected type 'bytes'
An error occured during public.delft_4D export.